### PR TITLE
Adds unit and integration tests to verify basic auth functionality

### DIFF
--- a/server/src/main/java/org/opensearch/identity/AuthenticationTokenHandler.java
+++ b/server/src/main/java/org/opensearch/identity/AuthenticationTokenHandler.java
@@ -57,7 +57,11 @@ public class AuthenticationTokenHandler {
 
         final byte[] decodedAuthHeader = Base64.getDecoder().decode(token.getHeaderValue().substring("Basic".length()).trim());
         String decodedHeader = new String(decodedAuthHeader, StandardCharsets.UTF_8);
+
         final String[] decodedUserNamePassword = decodedHeader.split(":");
+
+        // Malformed AuthHeader strings
+        if (decodedUserNamePassword.length != 2) return null;
 
         logger.info("Logging in as: " + decodedUserNamePassword[0]);
 

--- a/server/src/test/java/org/opensearch/identity/AuthenticationTokenHandlerTests.java
+++ b/server/src/test/java/org/opensearch/identity/AuthenticationTokenHandlerTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.identity;
+
+import org.hamcrest.MatcherAssert;
+import org.opensearch.authn.AuthenticationToken;
+import org.opensearch.authn.HttpHeaderToken;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class AuthenticationTokenHandlerTests extends OpenSearchTestCase {
+
+    public void testShouldExtractBasicAuthTokenSuccessfully() {
+
+        // The auth header that is part of the request
+        String authHeader = "Basic YWRtaW46YWRtaW4="; // admin:admin
+
+        AuthenticationToken authToken = new HttpHeaderToken(authHeader);
+
+        org.apache.shiro.authc.AuthenticationToken shiroAuthToken = AuthenticationTokenHandler.extractShiroAuthToken(authToken);
+
+        MatcherAssert.assertThat(shiroAuthToken, notNullValue());
+    }
+
+    public void testShouldReturnNullWhenExtractingInvalidToken() {
+        String authHeader = "Basic Nah";
+
+        AuthenticationToken authToken = new HttpHeaderToken(authHeader);
+
+        org.apache.shiro.authc.AuthenticationToken shiroAuthToken = AuthenticationTokenHandler.extractShiroAuthToken(authToken);
+
+        MatcherAssert.assertThat(shiroAuthToken, nullValue());
+    }
+
+    public void testShouldReturnNullWhenExtractingNullToken() {
+
+        org.apache.shiro.authc.AuthenticationToken shiroAuthToken = AuthenticationTokenHandler.extractShiroAuthToken(null);
+
+        MatcherAssert.assertThat(shiroAuthToken, nullValue());
+    }
+}

--- a/server/src/test/java/org/opensearch/identity/authn/BasicAuthenticationTests.java
+++ b/server/src/test/java/org/opensearch/identity/authn/BasicAuthenticationTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.identity.authn;
+
+import org.hamcrest.MatcherAssert;
+import org.opensearch.client.Request;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class BasicAuthenticationTests extends OpenSearchRestTestCase {
+
+    public void testClusterHealthWithValidAuthenticationHeader() throws IOException {
+        Request request = new Request("GET", "/_cluster/health");
+        RequestOptions options = RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "Basic YWRtaW46YWRtaW4=").build(); // admin:admin
+        request.setOptions(options);
+        Response response = client().performRequest(request);
+
+        assertOK(response);
+
+        // Standard cluster health response
+        MatcherAssert.assertThat(entityAsMap(response).size(), equalTo(17));
+        MatcherAssert.assertThat(entityAsMap(response).get("status"), equalTo("green"));
+
+    }
+
+    public void testClusterHealthWithNoHeader() throws IOException {
+        Request request = new Request("GET", "/_cluster/health");
+        RequestOptions options = RequestOptions.DEFAULT.toBuilder().build(); // admin:admin
+        request.setOptions(options);
+        Response response = client().performRequest(request);
+
+        // allowed if no authorization header was passed. Should be updated once that is fixed
+        assertOK(response);
+
+        // Standard cluster health response
+        MatcherAssert.assertThat(entityAsMap(response).size(), equalTo(17));
+        MatcherAssert.assertThat(entityAsMap(response).get("status"), equalTo("green"));
+
+    }
+
+    public void testClusterHealthWithInvalidAuthenticationHeader() throws IOException {
+        Request request = new Request("GET", "/_cluster/health");
+        RequestOptions options = RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "Basic bWFydmluOmdhbGF4eQ==").build(); // marvin:galaxy
+        request.setOptions(options);
+        Response response = client().performRequest(request);
+
+        // Should not fail, because current implementation allows a unauthorized request to pass
+        // TODO: Update this to test for UNAUTHORIZED once that flow is implemented
+        assertOK(response);
+
+        // Standard cluster health response
+        MatcherAssert.assertThat(entityAsMap(response).size(), equalTo(17));
+        MatcherAssert.assertThat(entityAsMap(response).get("status"), equalTo("green"));
+
+    }
+
+    public void testClusterHealthWithCorruptAuthenticationHeader() throws IOException {
+        Request request = new Request("GET", "/_cluster/health");
+        RequestOptions options = RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", "Basic bleh").build(); // marvin:galaxy
+        request.setOptions(options);
+        try {
+            client().performRequest(request);
+        } catch (ResponseException e) {
+            MatcherAssert.assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(405));
+        }
+
+    }
+}

--- a/server/src/test/java/org/opensearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/opensearch/rest/RestControllerTests.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.rest;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.breaker.CircuitBreaker;
 import org.opensearch.common.bytes.BytesArray;
@@ -52,6 +53,9 @@ import org.opensearch.http.HttpRequest;
 import org.opensearch.http.HttpResponse;
 import org.opensearch.http.HttpServerTransport;
 import org.opensearch.http.HttpStats;
+import org.opensearch.identity.AuthenticationManager;
+import org.opensearch.identity.Identity;
+import org.opensearch.identity.internal.InternalAuthenticationManager;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.client.NoOpNodeClient;
@@ -84,6 +88,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE) /* otherwise {@code testRestRequestAuthentication} cause thread to be leaked */
 public class RestControllerTests extends OpenSearchTestCase {
 
     private static final ByteSizeValue BREAKER_LIMIT = new ByteSizeValue(20);
@@ -636,6 +641,42 @@ public class RestControllerTests extends OpenSearchTestCase {
             channel.getRestResponse().content().utf8ToString(),
             equalTo("{\"error\":\"Unexpected HTTP method, allowed: [GET]\",\"status\":405}")
         );
+    }
+
+    // Tests to check authenticate(...) method
+    public void testRestRequestAuthenticationSuccess() {
+        final AuthenticationManager authManager = new InternalAuthenticationManager();
+        Identity.setAuthManager(authManager);
+
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+
+        final FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withHeaders(
+            Collections.singletonMap("Authorization", Collections.singletonList("Basic YWRtaW46YWRtaW4="))
+        ) // admin:admin
+            .build();
+        final AssertingChannel channel = new AssertingChannel(fakeRestRequest, true, RestStatus.OK);
+        restController.dispatchRequest(fakeRestRequest, channel, threadContext);
+
+        assertTrue(channel.getSendResponseCalled());
+    }
+
+    public void testRestRequestAuthenticationFailure() {
+        final AuthenticationManager authManager = new InternalAuthenticationManager();
+        Identity.setAuthManager(authManager);
+
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+
+        final FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withHeaders(
+            Collections.singletonMap("Authorization", Collections.singletonList("Basic bWFydmluOmdhbGF4eQ=="))
+        ) // marvin:galaxy
+            .build();
+
+        // RestStatus is OK even though the authn information is incorrect. This is because we, yet, don't fail the request
+        // if it was unauthorized. The status should be changed to UNAUTHORIZED once the flow is updated.
+        final AssertingChannel channel = new AssertingChannel(fakeRestRequest, true, RestStatus.OK);
+        restController.dispatchRequest(fakeRestRequest, channel, threadContext);
+
+        assertTrue(channel.getSendResponseCalled());
     }
 
     private static final class TestHttpServerTransport extends AbstractLifecycleComponent implements HttpServerTransport {


### PR DESCRIPTION
### Description
Adds tests for Basic Auth functionality added via: #4798 

### Issues Resolved

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
