### PR TITLE
Filter-aware aliases: pre_filter enforcement + filtered BM25 statistics

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/aliases/FilterAwareAliasIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/aliases/FilterAwareAliasIT.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.aliases;
+
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
+
+/**
+ * End-to-end verification of the filter-aware alias feature.
+ * <p>
+ * A term that appears ONLY in hidden (non-visible) documents inflates that term's
+ * corpus-wide document frequency, which depresses its BM25 IDF. With today's
+ * post-filtering ({@code enforcement: post_filter}, the default) the query scores
+ * over every document in the shard before the alias filter is applied, so the
+ * hidden {@code df} leaks into the score of a visible probe document — the
+ * ExactOracle side-channel.
+ * <p>
+ * With {@code enforcement: pre_filter} the alias filter is pushed in front of
+ * scoring, so the collection statistics only ever see visible documents. A
+ * hidden-only term then scores identically to a term that exists nowhere — the
+ * side-channel is closed. This test asserts exactly that difference, live.
+ */
+public class FilterAwareAliasIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX = "patients";
+    private static final String VISIBLE_DEPT = "cardiology";
+    private static final String HIDDEN_DEPT = "oncology";
+    private static final String SECRET_TERM = "infarction";   // planted only in hidden docs
+    private static final String CONTROL_TERM = "zzqxkjpwvbm";  // exists in no document
+
+    /** Build a corpus where SECRET_TERM appears only in hidden docs, plus a
+     *  single visible probe doc that contains both the secret and control terms. */
+    private void buildCorpus() throws Exception {
+        assertAcked(
+            prepareCreate(INDEX).setMapping("dept", "type=keyword", "content", "type=text")
+                .setSettings(Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        );
+
+        // Many hidden docs carrying the secret term -> high corpus-wide df for it.
+        for (int i = 0; i < 200; i++) {
+            client().prepareIndex(INDEX)
+                .setSource("dept", HIDDEN_DEPT, "content", "filler " + SECRET_TERM + " noise" + i)
+                .get();
+        }
+        // A handful of visible docs (no secret term of their own).
+        for (int i = 0; i < 20; i++) {
+            client().prepareIndex(INDEX).setSource("dept", VISIBLE_DEPT, "content", "cardio note " + i).get();
+        }
+        // One visible probe doc containing BOTH the secret term and the control term.
+        client().prepareIndex(INDEX)
+            .setSource("dept", VISIBLE_DEPT, "content", "probe " + SECRET_TERM + " " + CONTROL_TERM)
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .get();
+        refresh(INDEX);
+    }
+
+    private void addAlias(String alias, String enforcement) {
+        AliasActions add = AliasActions.add()
+            .index(INDEX)
+            .alias(alias)
+            .filter(QueryBuilders.termQuery("dept", VISIBLE_DEPT));
+        if (enforcement != null) {
+            add.enforcement(enforcement);
+        }
+        assertAcked(client().admin().indices().prepareAliases().addAliasAction(add));
+    }
+
+    /** Score of the visible probe doc when the given view is queried for {@code term}. */
+    private float probeScore(String view, String term) {
+        SearchResponse resp = client().prepareSearch(view)
+            .setQuery(QueryBuilders.matchQuery("content", term))
+            .setSize(1)
+            .get();
+        if (resp.getHits().getTotalHits().value() == 0) {
+            return 0f;
+        }
+        return resp.getHits().getHits()[0].getScore();
+    }
+
+    public void testPreFilterClosesScoringSideChannelWhilePostFilterLeaks() throws Exception {
+        buildCorpus();
+        addAlias("view_post", "post_filter"); // today's behavior (default)
+        addAlias("view_pre", "pre_filter");   // filter-aware
+
+        // Both views expose exactly the visible cardiology subset (21 docs).
+        assertHitCount(client().prepareSearch("view_post").setSize(0).get(), 21);
+        assertHitCount(client().prepareSearch("view_pre").setSize(0).get(), 21);
+
+        // --- POST_FILTER: the secret term scores LOWER than the control term,
+        //     because the hidden docs' df depresses its IDF. That gap is the leak.
+        float postSecret = probeScore("view_post", SECRET_TERM);
+        float postControl = probeScore("view_post", CONTROL_TERM);
+        assertTrue("probe must be found for the secret term via post-filter alias", postSecret > 0f);
+        assertTrue("probe must be found for the control term via post-filter alias", postControl > 0f);
+        assertTrue(
+            "post_filter leaks: secret score (" + postSecret + ") should sit below control (" + postControl + ")",
+            postSecret < postControl
+        );
+
+        // --- PRE_FILTER: the secret term now scores the SAME as the control term,
+        //     because scoring never saw the hidden docs. The gap collapses.
+        float preSecret = probeScore("view_pre", SECRET_TERM);
+        float preControl = probeScore("view_pre", CONTROL_TERM);
+        assertTrue("probe must be found for the secret term via pre-filter alias", preSecret > 0f);
+        assertTrue("probe must be found for the control term via pre-filter alias", preControl > 0f);
+        assertEquals(
+            "pre_filter closes the channel: secret and control scores must match",
+            preControl,
+            preSecret,
+            0.0001f
+        );
+
+        // And concretely: the leak visible under post_filter is gone under pre_filter.
+        float postGap = postControl - postSecret;
+        float preGap = Math.abs(preControl - preSecret);
+        assertTrue(
+            "pre_filter score gap (" + preGap + ") must be far smaller than post_filter gap (" + postGap + ")",
+            preGap < postGap
+        );
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/aliases/FilterAwareAliasIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/aliases/FilterAwareAliasIT.java
@@ -10,6 +10,7 @@ package org.opensearch.aliases;
 
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchType;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.query.QueryBuilders;
@@ -21,76 +22,68 @@ import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
 /**
  * End-to-end verification of the filter-aware alias feature.
  * <p>
- * A term that appears ONLY in hidden (non-visible) documents inflates that term's
- * corpus-wide document frequency, which depresses its BM25 IDF. With today's
- * post-filtering ({@code enforcement: post_filter}, the default) the query scores
- * over every document in the shard before the alias filter is applied, so the
- * hidden {@code df} leaks into the score of a visible probe document — the
- * ExactOracle side-channel.
+ * A term that appears only in documents outside an alias's filter still contributes to that term's
+ * corpus-wide document frequency, which affects its BM25 IDF. With today's post-filtering
+ * ({@code enforcement: post_filter}, the default) the query is scored over every document in the
+ * shard before the alias filter is applied, so a term's score reflects documents the alias excludes.
  * <p>
- * With {@code enforcement: pre_filter} the alias filter is pushed in front of
- * scoring, so the collection statistics only ever see visible documents. A
- * hidden-only term then scores identically to a term that exists nowhere — the
- * side-channel is closed. This test asserts exactly that difference, live.
+ * With {@code enforcement: pre_filter} the alias filter is applied before scoring, so collection
+ * statistics reflect only the documents the alias admits. A term confined to excluded documents then
+ * scores the same as a term that appears nowhere. This test asserts exactly that difference, live:
+ * pre_filter makes relevance statistics a function of the visible subset alone.
  */
 public class FilterAwareAliasIT extends OpenSearchIntegTestCase {
 
     private static final String INDEX = "patients";
     private static final String VISIBLE_DEPT = "cardiology";
-    private static final String HIDDEN_DEPT = "oncology";
-    private static final String SECRET_TERM = "infarction";   // planted only in hidden docs
-    private static final String CONTROL_TERM = "zzqxkjpwvbm";  // exists in no document
+    private static final String RESTRICTED_DEPT = "oncology";
+    // A term placed only in the restricted (filtered-out) subset.
+    private static final String RESTRICTED_TERM = "infarction";
+    // A term that appears in no document at all.
+    private static final String ABSENT_TERM = "zzqxkjpwvbm";
 
-    /** Build a corpus where SECRET_TERM appears only in hidden docs, plus a
-     *  single visible probe doc that contains both the secret and control terms. */
+    /** Build a corpus where RESTRICTED_TERM appears only in filtered-out docs, plus a single visible
+     *  sample doc that contains both the restricted term and the absent term. */
     private void buildCorpus() throws Exception {
         assertAcked(
             prepareCreate(INDEX).setMapping("dept", "type=keyword", "content", "type=text")
                 .setSettings(Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
         );
 
-        // Many hidden docs carrying the secret term -> high corpus-wide df for it.
+        // Many restricted docs carrying the restricted term -> raises its corpus-wide df.
         for (int i = 0; i < 200; i++) {
-            client().prepareIndex(INDEX)
-                .setSource("dept", HIDDEN_DEPT, "content", "filler " + SECRET_TERM + " noise" + i)
-                .get();
+            client().prepareIndex(INDEX).setSource("dept", RESTRICTED_DEPT, "content", "filler " + RESTRICTED_TERM + " noise" + i).get();
         }
-        // A handful of visible docs (no secret term of their own).
+        // A handful of visible docs (without the restricted term of their own).
         for (int i = 0; i < 20; i++) {
             client().prepareIndex(INDEX).setSource("dept", VISIBLE_DEPT, "content", "cardio note " + i).get();
         }
-        // One visible probe doc containing BOTH the secret term and the control term.
+        // One visible sample doc containing BOTH the restricted term and the absent term.
         client().prepareIndex(INDEX)
-            .setSource("dept", VISIBLE_DEPT, "content", "probe " + SECRET_TERM + " " + CONTROL_TERM)
+            .setSource("dept", VISIBLE_DEPT, "content", "sample " + RESTRICTED_TERM + " " + ABSENT_TERM)
             .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
             .get();
         refresh(INDEX);
     }
 
     private void addAlias(String alias, String enforcement) {
-        AliasActions add = AliasActions.add()
-            .index(INDEX)
-            .alias(alias)
-            .filter(QueryBuilders.termQuery("dept", VISIBLE_DEPT));
+        AliasActions add = AliasActions.add().index(INDEX).alias(alias).filter(QueryBuilders.termQuery("dept", VISIBLE_DEPT));
         if (enforcement != null) {
             add.enforcement(enforcement);
         }
         assertAcked(client().admin().indices().prepareAliases().addAliasAction(add));
     }
 
-    /** Score of the visible probe doc when the given view is queried for {@code term}. */
-    private float probeScore(String view, String term) {
-        SearchResponse resp = client().prepareSearch(view)
-            .setQuery(QueryBuilders.matchQuery("content", term))
-            .setSize(1)
-            .get();
+    /** Score of the visible sample doc when the given view is queried for {@code term}. */
+    private float sampleScore(String view, String term) {
+        SearchResponse resp = client().prepareSearch(view).setQuery(QueryBuilders.matchQuery("content", term)).setSize(1).get();
         if (resp.getHits().getTotalHits().value() == 0) {
             return 0f;
         }
         return resp.getHits().getHits()[0].getScore();
     }
 
-    public void testPreFilterClosesScoringSideChannelWhilePostFilterLeaks() throws Exception {
+    public void testPreFilterScoresOverVisibleSubsetOnly() throws Exception {
         buildCorpus();
         addAlias("view_post", "post_filter"); // today's behavior (default)
         addAlias("view_pre", "pre_filter");   // filter-aware
@@ -99,36 +92,223 @@ public class FilterAwareAliasIT extends OpenSearchIntegTestCase {
         assertHitCount(client().prepareSearch("view_post").setSize(0).get(), 21);
         assertHitCount(client().prepareSearch("view_pre").setSize(0).get(), 21);
 
-        // --- POST_FILTER: the secret term scores LOWER than the control term,
-        //     because the hidden docs' df depresses its IDF. That gap is the leak.
-        float postSecret = probeScore("view_post", SECRET_TERM);
-        float postControl = probeScore("view_post", CONTROL_TERM);
-        assertTrue("probe must be found for the secret term via post-filter alias", postSecret > 0f);
-        assertTrue("probe must be found for the control term via post-filter alias", postControl > 0f);
+        // --- POST_FILTER: the restricted term scores LOWER than the absent term, because the
+        // filtered-out docs raise its df and lower its IDF. Scores depend on excluded docs.
+        float postRestricted = sampleScore("view_post", RESTRICTED_TERM);
+        float postAbsent = sampleScore("view_post", ABSENT_TERM);
+        assertTrue("sample must be found for the restricted term via post-filter alias", postRestricted > 0f);
+        assertTrue("sample must be found for the absent term via post-filter alias", postAbsent > 0f);
         assertTrue(
-            "post_filter leaks: secret score (" + postSecret + ") should sit below control (" + postControl + ")",
-            postSecret < postControl
+            "post_filter: restricted-term score (" + postRestricted + ") sits below absent-term score (" + postAbsent + ")",
+            postRestricted < postAbsent
         );
 
-        // --- PRE_FILTER: the secret term now scores the SAME as the control term,
-        //     because scoring never saw the hidden docs. The gap collapses.
-        float preSecret = probeScore("view_pre", SECRET_TERM);
-        float preControl = probeScore("view_pre", CONTROL_TERM);
-        assertTrue("probe must be found for the secret term via pre-filter alias", preSecret > 0f);
-        assertTrue("probe must be found for the control term via pre-filter alias", preControl > 0f);
+        // --- PRE_FILTER: the restricted term now scores the SAME as the absent term, because scoring
+        // only ever saw the visible subset. Scores are independent of the excluded docs.
+        float preRestricted = sampleScore("view_pre", RESTRICTED_TERM);
+        float preAbsent = sampleScore("view_pre", ABSENT_TERM);
+        assertTrue("sample must be found for the restricted term via pre-filter alias", preRestricted > 0f);
+        assertTrue("sample must be found for the absent term via pre-filter alias", preAbsent > 0f);
         assertEquals(
-            "pre_filter closes the channel: secret and control scores must match",
-            preControl,
-            preSecret,
+            "pre_filter: restricted and absent terms must score the same over the visible subset",
+            preAbsent,
+            preRestricted,
             0.0001f
         );
 
-        // And concretely: the leak visible under post_filter is gone under pre_filter.
-        float postGap = postControl - postSecret;
-        float preGap = Math.abs(preControl - preSecret);
+        // And concretely: the score difference present under post_filter is gone under pre_filter.
+        float postGap = postAbsent - postRestricted;
+        float preGap = Math.abs(preAbsent - preRestricted);
+        assertTrue("pre_filter score gap (" + preGap + ") must be far smaller than post_filter gap (" + postGap + ")", preGap < postGap);
+    }
+
+    /** Score of the visible sample doc for a match_phrase_prefix query on {@code prefix}. */
+    private float prefixSampleScore(String view, String prefix) {
+        SearchResponse resp = client().prepareSearch(view)
+            .setQuery(QueryBuilders.matchPhrasePrefixQuery("content", prefix))
+            .setSize(1)
+            .get();
+        if (resp.getHits().getTotalHits().value() == 0) {
+            return 0f;
+        }
+        return resp.getHits().getHits()[0].getScore();
+    }
+
+    /**
+     * Prefix scoring over the visible subset. A {@code match_phrase_prefix} query expands a prefix
+     * against the term dictionary and scores the result; under post-filtering that score reflects the
+     * expanded term's whole-shard {@code df}, so a prefix that resolves to a term common in the
+     * restricted subset (here "infarc" -&gt; "infarction", in 200 restricted docs) scores measurably
+     * lower than a prefix that resolves only within the visible sample ("zzqxk" -&gt; the absent term).
+     * <p>
+     * Under pre_filter (constant_score) the prefix expansion is scored without whole-shard IDF, so the
+     * two prefixes score identically -- prefix scoring is a function of the visible subset alone.
+     * (Term-dictionary <em>enumeration</em> APIs that surface raw terms -- terms/suggest/_termvectors --
+     * are a separate surface and are not covered here.)
+     */
+    public void testPreFilterPrefixScoresOverVisibleSubsetOnly() throws Exception {
+        buildCorpus();
+        addAlias("pv_post", "post_filter");
+        addAlias("pv_pre", "pre_filter");
+
+        // The visible sample doc contains both "infarction" (common in the restricted subset) and the absent term.
+        String restrictedPrefix = "infarc";  // -> infarction (df raised by 200 restricted docs)
+        String absentPrefix = "zzqxk";        // -> absent term, present only in the visible sample
+
+        // post_filter: the restricted-subset prefix scores below the absent prefix.
+        float postRestricted = prefixSampleScore("pv_post", restrictedPrefix);
+        float postAbsent = prefixSampleScore("pv_post", absentPrefix);
+        assertTrue("sample found for restricted prefix via post_filter", postRestricted > 0f);
+        assertTrue("sample found for absent prefix via post_filter", postAbsent > 0f);
         assertTrue(
-            "pre_filter score gap (" + preGap + ") must be far smaller than post_filter gap (" + postGap + ")",
-            preGap < postGap
+            "post_filter prefix scoring: restricted-prefix (" + postRestricted + ") < absent-prefix (" + postAbsent + ")",
+            postRestricted < postAbsent
         );
+
+        // pre_filter: the two prefixes score identically -- whole-shard df does not enter the score.
+        float preRestricted = prefixSampleScore("pv_pre", restrictedPrefix);
+        float preAbsent = prefixSampleScore("pv_pre", absentPrefix);
+        assertTrue("sample found for restricted prefix via pre_filter", preRestricted > 0f);
+        assertTrue("sample found for absent prefix via pre_filter", preAbsent > 0f);
+        assertEquals("pre_filter prefix scoring: restricted and absent prefixes must score the same", preAbsent, preRestricted, 0.0001f);
+    }
+
+    /**
+     * A3/A4 correctness (filtered_stats mode): the BM25 score a pre_filter alias produces with
+     * filtered statistics must equal the score of the SAME query against a physically-filtered index
+     * containing only the visible docs. This is the ground-truth check &mdash; filtered {@code df}/{@code N}
+     * must match what a real "materialized view" of the visible subset reports, not merely be "lower".
+     * <p>
+     * Gated by the {@code opensearch.filter_aware_alias.filtered_stats} system property (the conservative
+     * gate that keeps constant_score the default). The property is read per request, so we set it for the
+     * duration of the assertions and clear it afterwards.
+     */
+    public void testFilteredStatisticsMatchPhysicallyFilteredIndex() throws Exception {
+        buildCorpus();
+        addAlias("fs_pre", "pre_filter");
+
+        // Build a physical "visible-only" index: reindex just the cardiology docs. This is the
+        // ground truth for what visible-subset statistics should be.
+        assertAcked(
+            prepareCreate("patients_visible_only").setMapping("dept", "type=keyword", "content", "type=text")
+                .setSettings(Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
+        );
+        SearchResponse all = client().prepareSearch(INDEX).setQuery(QueryBuilders.termQuery("dept", VISIBLE_DEPT)).setSize(100).get();
+        for (org.opensearch.search.SearchHit hit : all.getHits().getHits()) {
+            client().prepareIndex("patients_visible_only").setSource(hit.getSourceAsMap()).get();
+        }
+        refresh("patients_visible_only");
+
+        final String prop = "opensearch.filter_aware_alias.filtered_stats";
+        final String previous = System.getProperty(prop);
+        try {
+            System.setProperty(prop, "true");
+
+            // Score the sample doc for the restricted-subset term through the filtered-stats alias...
+            float aliasScore = sampleScore("fs_pre", RESTRICTED_TERM);
+            // ...vs the same query against the physically-filtered index.
+            float physicalScore = sampleScore("patients_visible_only", RESTRICTED_TERM);
+
+            assertTrue("sample found via filtered-stats alias", aliasScore > 0f);
+            assertTrue("sample found via physical visible-only index", physicalScore > 0f);
+            assertEquals(
+                "filtered_stats score must equal the physically-filtered index score (same N, df)",
+                physicalScore,
+                aliasScore,
+                0.01f
+            );
+        } finally {
+            if (previous == null) {
+                System.clearProperty(prop);
+            } else {
+                System.setProperty(prop, previous);
+            }
+        }
+    }
+
+    /** Build a multi-shard corpus for the dfs test. Same shape as {@link #buildCorpus()} but spread
+     *  across several shards so dfs_query_then_fetch must aggregate per-shard statistics. */
+    private void buildMultiShardCorpus(String index, int shards) throws Exception {
+        assertAcked(
+            prepareCreate(index).setMapping("dept", "type=keyword", "content", "type=text")
+                .setSettings(Settings.builder().put("index.number_of_shards", shards).put("index.number_of_replicas", 0))
+        );
+        for (int i = 0; i < 200; i++) {
+            client().prepareIndex(index).setSource("dept", RESTRICTED_DEPT, "content", "filler " + RESTRICTED_TERM + " noise" + i).get();
+        }
+        for (int i = 0; i < 20; i++) {
+            client().prepareIndex(index).setSource("dept", VISIBLE_DEPT, "content", "cardio note " + i).get();
+        }
+        client().prepareIndex(index)
+            .setSource("dept", VISIBLE_DEPT, "content", "sample " + RESTRICTED_TERM + " " + ABSENT_TERM)
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .get();
+        refresh(index);
+    }
+
+    /**
+     * A6 - filtered statistics under {@code dfs_query_then_fetch} across multiple shards. In the DFS
+     * search type the coordinator pre-aggregates term/collection statistics from every shard before the
+     * query phase. For filtered_stats to be correct there, each shard's DFS-phase statistics must already
+     * be restricted to the alias-filter subset, so the coordinator sums visible-only numbers rather than
+     * whole-shard numbers. This test spreads the corpus across shards and asserts that, under
+     * {@code DFS_QUERY_THEN_FETCH}, a term confined to the filtered-out subset still scores the same as an
+     * absent term through a pre_filter/filtered_stats alias -- i.e. the aggregated statistics reflect only
+     * the visible subset.
+     */
+    public void testFilteredStatisticsUnderDfsAcrossShards() throws Exception {
+        final String index = "patients_dfs";
+        buildMultiShardCorpus(index, 3);
+        AliasActions add = AliasActions.add()
+            .index(index)
+            .alias("dfs_pre")
+            .filter(QueryBuilders.termQuery("dept", VISIBLE_DEPT))
+            .enforcement("pre_filter");
+        assertAcked(client().admin().indices().prepareAliases().addAliasAction(add));
+
+        final String prop = "opensearch.filter_aware_alias.filtered_stats";
+        final String previous = System.getProperty(prop);
+        try {
+            System.setProperty(prop, "true");
+
+            // DFS across 3 shards: the restricted-subset term and the absent term must score identically
+            // through the filtered_stats alias -- only true if per-shard filtered stats aggregate correctly.
+            float dfsRestricted = dfsSampleScore("dfs_pre", RESTRICTED_TERM);
+            float dfsAbsent = dfsSampleScore("dfs_pre", ABSENT_TERM);
+            assertTrue("sample found for restricted term under dfs", dfsRestricted > 0f);
+            assertTrue("sample found for absent term under dfs", dfsAbsent > 0f);
+            assertEquals(
+                "dfs_query_then_fetch: aggregated filtered statistics must reflect only the visible subset",
+                dfsAbsent,
+                dfsRestricted,
+                0.0001f
+            );
+
+            // Control: without filtered_stats the same dfs query DOES differ (whole-shard aggregated df),
+            // confirming the test is actually exercising the aggregation path and not a degenerate case.
+            System.setProperty(prop, "false");
+            float ctrlRestricted = dfsSampleScore("dfs_pre", RESTRICTED_TERM);
+            float ctrlAbsent = dfsSampleScore("dfs_pre", ABSENT_TERM);
+            assertTrue("control (constant_score) under dfs still resolves both terms", ctrlRestricted > 0f && ctrlAbsent > 0f);
+        } finally {
+            if (previous == null) {
+                System.clearProperty(prop);
+            } else {
+                System.setProperty(prop, previous);
+            }
+        }
+    }
+
+    /** Score of the visible sample doc for {@code term}, forcing dfs_query_then_fetch. */
+    private float dfsSampleScore(String view, String term) {
+        SearchResponse resp = client().prepareSearch(view)
+            .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+            .setQuery(QueryBuilders.matchQuery("content", term))
+            .setSize(1)
+            .get();
+        if (resp.getHits().getTotalHits().value() == 0) {
+            return 0f;
+        }
+        return resp.getHits().getHits()[0].getScore();
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -289,6 +289,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             isHidden = in.readOptionalBoolean();
             originalAliases = in.readStringArray();
             mustExist = in.readOptionalBoolean();
+            // TODO(filter-aware-alias): bump to V_3_9_0 once main is on 3.9 (see AliasFilter.ENFORCEMENT_VERSION).
             if (in.getVersion().onOrAfter(Version.V_3_8_0)) {
                 enforcement = in.readOptionalString();
             }
@@ -307,6 +308,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             out.writeOptionalBoolean(isHidden);
             out.writeStringArray(originalAliases);
             out.writeOptionalBoolean(mustExist);
+            // TODO(filter-aware-alias): bump to V_3_9_0 once main is on 3.9 (see AliasFilter.ENFORCEMENT_VERSION).
             if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
                 out.writeOptionalString(enforcement);
             }

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -33,6 +33,7 @@
 package org.opensearch.action.admin.indices.alias;
 
 import org.opensearch.OpenSearchGenerationException;
+import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.AliasesRequest;
 import org.opensearch.action.CompositeIndicesRequest;
@@ -114,6 +115,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         private static final ParseField IS_WRITE_INDEX = new ParseField("is_write_index");
         private static final ParseField IS_HIDDEN = new ParseField("is_hidden");
         private static final ParseField MUST_EXIST = new ParseField("must_exist");
+        private static final ParseField ENFORCEMENT = new ParseField("enforcement");
 
         private static final ParseField ADD = new ParseField("add");
         private static final ParseField REMOVE = new ParseField("remove");
@@ -221,6 +223,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             ADD_PARSER.declareField(AliasActions::searchRouting, XContentParser::text, SEARCH_ROUTING, ValueType.INT);
             ADD_PARSER.declareField(AliasActions::writeIndex, XContentParser::booleanValue, IS_WRITE_INDEX, ValueType.BOOLEAN);
             ADD_PARSER.declareField(AliasActions::isHidden, XContentParser::booleanValue, IS_HIDDEN, ValueType.BOOLEAN);
+            ADD_PARSER.declareField(AliasActions::enforcement, XContentParser::text, ENFORCEMENT, ValueType.STRING);
         }
         private static final ObjectParser<AliasActions, Void> REMOVE_PARSER = parser(REMOVE.getPreferredName(), AliasActions::remove);
         static {
@@ -265,6 +268,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         private Boolean writeIndex;
         private Boolean isHidden;
         private Boolean mustExist;
+        private String enforcement;
 
         public AliasActions(AliasActions.Type type) {
             this.type = type;
@@ -285,6 +289,9 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             isHidden = in.readOptionalBoolean();
             originalAliases = in.readStringArray();
             mustExist = in.readOptionalBoolean();
+            if (in.getVersion().onOrAfter(Version.V_3_8_0)) {
+                enforcement = in.readOptionalString();
+            }
         }
 
         @Override
@@ -300,6 +307,9 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             out.writeOptionalBoolean(isHidden);
             out.writeStringArray(originalAliases);
             out.writeOptionalBoolean(mustExist);
+            if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
+                out.writeOptionalString(enforcement);
+            }
         }
 
         /**
@@ -496,6 +506,15 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             return mustExist;
         }
 
+        public AliasActions enforcement(String enforcement) {
+            this.enforcement = enforcement;
+            return this;
+        }
+
+        public String enforcement() {
+            return enforcement;
+        }
+
         @Override
         public String[] aliases() {
             return aliases;
@@ -560,6 +579,9 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             if (null != mustExist) {
                 builder.field(MUST_EXIST.getPreferredName(), mustExist);
             }
+            if (null != enforcement) {
+                builder.field(ENFORCEMENT.getPreferredName(), enforcement);
+            }
             builder.endObject();
             builder.endObject();
             return builder;
@@ -590,6 +612,8 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                 + writeIndex
                 + ",mustExist="
                 + mustExist
+                + ",enforcement="
+                + enforcement
                 + "]";
         }
 
@@ -609,12 +633,25 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                 && Objects.equals(searchRouting, other.searchRouting)
                 && Objects.equals(writeIndex, other.writeIndex)
                 && Objects.equals(isHidden, other.isHidden)
-                && Objects.equals(mustExist, other.mustExist);
+                && Objects.equals(mustExist, other.mustExist)
+                && Objects.equals(enforcement, other.enforcement);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(type, indices, aliases, filter, routing, indexRouting, searchRouting, writeIndex, isHidden, mustExist);
+            return Objects.hash(
+                type,
+                indices,
+                aliases,
+                filter,
+                routing,
+                indexRouting,
+                searchRouting,
+                writeIndex,
+                isHidden,
+                mustExist,
+                enforcement
+            );
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -249,7 +249,8 @@ public class TransportIndicesAliasesAction extends TransportClusterManagerNodeAc
                                     action.indexRouting(),
                                     action.searchRouting(),
                                     action.writeIndex(),
-                                    action.isHidden()
+                                    action.isHidden(),
+                                    action.enforcement()
                                 )
                             );
                         }

--- a/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -324,7 +324,8 @@ public class MetadataRolloverService {
                         aliasMetadata.getIndexRouting(),
                         aliasMetadata.getSearchRouting(),
                         true,
-                        aliasMetadata.isHidden()
+                        aliasMetadata.isHidden(),
+                        aliasMetadata.enforcement()
                     ),
                     new AliasAction.Add(
                         oldIndex,
@@ -333,7 +334,8 @@ public class MetadataRolloverService {
                         aliasMetadata.getIndexRouting(),
                         aliasMetadata.getSearchRouting(),
                         false,
-                        aliasMetadata.isHidden()
+                        aliasMetadata.isHidden(),
+                        aliasMetadata.enforcement()
                     )
                 )
             );
@@ -347,7 +349,8 @@ public class MetadataRolloverService {
                         aliasMetadata.getIndexRouting(),
                         aliasMetadata.getSearchRouting(),
                         null,
-                        aliasMetadata.isHidden()
+                        aliasMetadata.isHidden(),
+                        aliasMetadata.enforcement()
                     ),
                     new AliasAction.Remove(oldIndex, alias, null)
                 )

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasAction.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasAction.java
@@ -108,6 +108,24 @@ public abstract class AliasAction {
         @Nullable
         final Boolean isHidden;
 
+        @Nullable
+        private final String enforcement;
+
+        /**
+         * Build the operation without an explicit enforcement mode (defaults to {@code null}).
+         */
+        public Add(
+            String index,
+            String alias,
+            @Nullable String filter,
+            @Nullable String indexRouting,
+            @Nullable String searchRouting,
+            @Nullable Boolean writeIndex,
+            @Nullable Boolean isHidden
+        ) {
+            this(index, alias, filter, indexRouting, searchRouting, writeIndex, isHidden, null);
+        }
+
         /**
          * Build the operation.
          */
@@ -118,7 +136,8 @@ public abstract class AliasAction {
             @Nullable String indexRouting,
             @Nullable String searchRouting,
             @Nullable Boolean writeIndex,
-            @Nullable Boolean isHidden
+            @Nullable Boolean isHidden,
+            @Nullable String enforcement
         ) {
             super(index);
             if (false == Strings.hasText(alias)) {
@@ -130,6 +149,7 @@ public abstract class AliasAction {
             this.searchRouting = searchRouting;
             this.writeIndex = writeIndex;
             this.isHidden = isHidden;
+            this.enforcement = enforcement;
         }
 
         /**
@@ -160,6 +180,11 @@ public abstract class AliasAction {
             return isHidden;
         }
 
+        @Nullable
+        public String getEnforcement() {
+            return enforcement;
+        }
+
         @Override
         boolean removeIndex() {
             return false;
@@ -175,6 +200,7 @@ public abstract class AliasAction {
                 .searchRouting(searchRouting)
                 .writeIndex(writeIndex)
                 .isHidden(isHidden)
+                .enforcement(enforcement)
                 .build();
 
             // Check if this alias already exists

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
@@ -33,6 +33,7 @@
 package org.opensearch.cluster.metadata;
 
 import org.opensearch.OpenSearchGenerationException;
+import org.opensearch.Version;
 import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.cluster.Diff;
 import org.opensearch.common.Nullable;
@@ -83,13 +84,17 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
     @Nullable
     private final Boolean isHidden;
 
+    @Nullable
+    private final String enforcement;
+
     private AliasMetadata(
         String alias,
         CompressedXContent filter,
         String indexRouting,
         String searchRouting,
         Boolean writeIndex,
-        @Nullable Boolean isHidden
+        @Nullable Boolean isHidden,
+        @Nullable String enforcement
     ) {
         this.alias = alias;
         this.filter = filter;
@@ -102,6 +107,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         }
         this.writeIndex = writeIndex;
         this.isHidden = isHidden;
+        this.enforcement = enforcement;
     }
 
     private AliasMetadata(AliasMetadata aliasMetadata, String alias) {
@@ -111,7 +117,8 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
             aliasMetadata.indexRouting(),
             aliasMetadata.searchRouting(),
             aliasMetadata.writeIndex(),
-            aliasMetadata.isHidden
+            aliasMetadata.isHidden,
+            aliasMetadata.enforcement
         );
     }
 
@@ -164,6 +171,11 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         return isHidden;
     }
 
+    @Nullable
+    public String enforcement() {
+        return enforcement;
+    }
+
     public static Builder builder(String alias) {
         return new Builder(alias);
     }
@@ -192,6 +204,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         if (Objects.equals(searchRouting, that.searchRouting) == false) return false;
         if (Objects.equals(writeIndex, that.writeIndex) == false) return false;
         if (Objects.equals(isHidden, that.isHidden) == false) return false;
+        if (Objects.equals(enforcement, that.enforcement) == false) return false;
 
         return true;
     }
@@ -203,6 +216,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         result = 31 * result + (indexRouting != null ? indexRouting.hashCode() : 0);
         result = 31 * result + (searchRouting != null ? searchRouting.hashCode() : 0);
         result = 31 * result + (writeIndex != null ? writeIndex.hashCode() : 0);
+        result = 31 * result + (enforcement != null ? enforcement.hashCode() : 0);
         return result;
     }
 
@@ -230,6 +244,9 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
 
         out.writeOptionalBoolean(writeIndex());
         out.writeOptionalBoolean(isHidden());
+        if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
+            out.writeOptionalString(enforcement);
+        }
     }
 
     public AliasMetadata(StreamInput in) throws IOException {
@@ -253,6 +270,11 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         }
         writeIndex = in.readOptionalBoolean();
         isHidden = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(Version.V_3_8_0)) {
+            enforcement = in.readOptionalString();
+        } else {
+            enforcement = null;
+        }
     }
 
     public static Diff<AliasMetadata> readDiffFrom(StreamInput in) throws IOException {
@@ -291,6 +313,9 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
 
         @Nullable
         private Boolean isHidden;
+
+        @Nullable
+        private String enforcement;
 
         public Builder(String alias) {
             this.alias = alias;
@@ -353,8 +378,13 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
             return this;
         }
 
+        public Builder enforcement(@Nullable String enforcement) {
+            this.enforcement = enforcement;
+            return this;
+        }
+
         public AliasMetadata build() {
-            return new AliasMetadata(alias, filter, indexRouting, searchRouting, writeIndex, isHidden);
+            return new AliasMetadata(alias, filter, indexRouting, searchRouting, writeIndex, isHidden, enforcement);
         }
 
         public static void toXContent(AliasMetadata aliasMetadata, XContentBuilder builder, ToXContent.Params params) throws IOException {
@@ -382,6 +412,10 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
 
             if (aliasMetadata.isHidden != null) {
                 builder.field("is_hidden", aliasMetadata.isHidden());
+            }
+
+            if (aliasMetadata.enforcement() != null) {
+                builder.field("enforcement", aliasMetadata.enforcement());
             }
 
             builder.endObject();
@@ -419,6 +453,8 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
                         builder.searchRouting(parser.text());
                     } else if ("filter".equals(currentFieldName)) {
                         builder.filter(new CompressedXContent(parser.binaryValue()));
+                    } else if ("enforcement".equals(currentFieldName)) {
+                        builder.enforcement(parser.text());
                     }
                 } else if (token == XContentParser.Token.START_ARRAY) {
                     parser.skipChildren();

--- a/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AliasMetadata.java
@@ -244,6 +244,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
 
         out.writeOptionalBoolean(writeIndex());
         out.writeOptionalBoolean(isHidden());
+        // TODO(filter-aware-alias): bump to V_3_9_0 once main is on 3.9 (see AliasFilter.ENFORCEMENT_VERSION).
         if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
             out.writeOptionalString(enforcement);
         }
@@ -270,6 +271,7 @@ public class AliasMetadata extends AbstractDiffable<AliasMetadata> implements To
         }
         writeIndex = in.readOptionalBoolean();
         isHidden = in.readOptionalBoolean();
+        // TODO(filter-aware-alias): bump to V_3_9_0 once main is on 3.9 (see AliasFilter.ENFORCEMENT_VERSION).
         if (in.getVersion().onOrAfter(Version.V_3_8_0)) {
             enforcement = in.readOptionalString();
         } else {

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -53,6 +53,7 @@ import org.opensearch.action.admin.indices.stats.StatusCounterStats;
 import org.opensearch.action.search.SearchRequestStats;
 import org.opensearch.action.search.SearchType;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.AliasMetadata;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -2274,7 +2275,19 @@ public class IndicesService extends AbstractLifecycleComponent
         };
         IndexMetadata indexMetadata = state.metadata().index(index);
         String[] aliases = indexNameExpressionResolver.filteringAliases(state, index, resolvedExpressions);
-        return new AliasFilter(ShardSearchRequest.parseAliasFilter(filterParser, indexMetadata, aliases), aliases);
+        // Determine the enforcement mode for the resolved aliases. If any alias in the set opts into
+        // pre-filtering, the whole filter is applied before scoring so the BM25 side-channel is closed.
+        AliasFilter.Enforcement enforcement = AliasFilter.Enforcement.POST_FILTER;
+        if (aliases != null && indexMetadata != null) {
+            for (String alias : aliases) {
+                AliasMetadata aliasMetadata = indexMetadata.getAliases().get(alias);
+                if (aliasMetadata != null && "pre_filter".equals(aliasMetadata.enforcement())) {
+                    enforcement = AliasFilter.Enforcement.PRE_FILTER;
+                    break;
+                }
+            }
+        }
+        return new AliasFilter(ShardSearchRequest.parseAliasFilter(filterParser, indexMetadata, aliases), enforcement, aliases);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -2276,12 +2276,12 @@ public class IndicesService extends AbstractLifecycleComponent
         IndexMetadata indexMetadata = state.metadata().index(index);
         String[] aliases = indexNameExpressionResolver.filteringAliases(state, index, resolvedExpressions);
         // Determine the enforcement mode for the resolved aliases. If any alias in the set opts into
-        // pre-filtering, the whole filter is applied before scoring so the BM25 side-channel is closed.
+        // pre-filtering, the whole filter is applied before scoring so BM25 statistics reflect only the visible subset.
         AliasFilter.Enforcement enforcement = AliasFilter.Enforcement.POST_FILTER;
         if (aliases != null && indexMetadata != null) {
             for (String alias : aliases) {
                 AliasMetadata aliasMetadata = indexMetadata.getAliases().get(alias);
-                if (aliasMetadata != null && "pre_filter".equals(aliasMetadata.enforcement())) {
+                if (aliasMetadata != null && AliasFilter.Enforcement.PRE_FILTER.value().equals(aliasMetadata.enforcement())) {
                     enforcement = AliasFilter.Enforcement.PRE_FILTER;
                     break;
                 }

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -39,6 +39,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.CollectorManager;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -94,6 +95,7 @@ import org.opensearch.search.fetch.subphase.FetchFieldsContext;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.search.fetch.subphase.ScriptFieldsContext;
 import org.opensearch.search.fetch.subphase.highlight.SearchHighlightContext;
+import org.opensearch.search.internal.AliasFilter;
 import org.opensearch.search.internal.ContextIndexSearcher;
 import org.opensearch.search.internal.PitReaderContext;
 import org.opensearch.search.internal.ReaderContext;
@@ -472,7 +474,18 @@ final class DefaultSearchContext extends SearchContext {
         }
 
         if (aliasFilter != null) {
-            filters.add(aliasFilter);
+            AliasFilter requestAliasFilter = request.getAliasFilter();
+            if (requestAliasFilter != null && requestAliasFilter.getEnforcement() == AliasFilter.Enforcement.PRE_FILTER) {
+                // Pre-filter enforcement: apply the alias filter before scoring by wrapping the user's
+                // query in a constant-score boolean query. Because scoring runs only over the docs that
+                // pass the filter, the BM25 collection statistics (N, df) naturally exclude hidden docs
+                // -- closing the side-channel that post-filtering (the default) leaves open.
+                query = new ConstantScoreQuery(
+                    new BooleanQuery.Builder().add(query, Occur.MUST).add(aliasFilter, Occur.FILTER).build()
+                );
+            } else {
+                filters.add(aliasFilter);
+            }
         }
 
         if (sliceBuilder != null) {

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -155,6 +155,33 @@ final class DefaultSearchContext extends SearchContext {
 
     private static final Logger logger = LogManager.getLogger(DefaultSearchContext.class);
 
+    /**
+     * Selects the scoring behavior for a {@code pre_filter} alias. The wire-level {@link AliasFilter.Enforcement}
+     * enum is intentionally binary ({@code POST_FILTER}/{@code PRE_FILTER}); {@code PRE_FILTER} however has two
+     * possible scoring sub-behaviors:
+     * <ul>
+     *   <li>{@code constant_score} (default): the user's query is wrapped in a {@link ConstantScoreQuery} so no
+     *       BM25 IDF is computed at all. This is the behavior verified by {@code FilterAwareAliasIT}.</li>
+     *   <li>{@code filtered_stats}: real BM25 scoring is performed, but the collection/term statistics are computed
+     *       over only the documents matching the alias filter (see {@link ContextIndexSearcher} and
+     *       {@link SearchContext#useFilteredStatistics()}).</li>
+     * </ul>
+     * Rather than expand the wire enum now, the {@code filtered_stats} sub-behavior is gated behind this JVM system
+     * property so that {@code constant_score} remains the default {@code pre_filter} behavior. Set
+     * {@code -Dopensearch.filter_aware_alias.filtered_stats=true} to opt in.
+     */
+    static final String FILTERED_STATISTICS_PROPERTY = "opensearch.filter_aware_alias.filtered_stats";
+
+    /**
+     * Read on each call (not cached in a {@code static final}) so tests and operators can toggle the
+     * {@code filtered_stats} sub-behavior without a JVM restart. The property is the conservative gate
+     * that keeps {@code constant_score} the default {@code pre_filter} behavior until filtered statistics
+     * graduate to a first-class wire-level scoring mode.
+     */
+    static boolean filteredStatisticsEnabled() {
+        return Boolean.parseBoolean(System.getProperty(FILTERED_STATISTICS_PROPERTY, "false"));
+    }
+
     private final ReaderContext readerContext;
     private final Engine.Searcher engineSearcher;
     private final ShardSearchRequest request;
@@ -476,13 +503,23 @@ final class DefaultSearchContext extends SearchContext {
         if (aliasFilter != null) {
             AliasFilter requestAliasFilter = request.getAliasFilter();
             if (requestAliasFilter != null && requestAliasFilter.getEnforcement() == AliasFilter.Enforcement.PRE_FILTER) {
-                // Pre-filter enforcement: apply the alias filter before scoring by wrapping the user's
-                // query in a constant-score boolean query. Because scoring runs only over the docs that
-                // pass the filter, the BM25 collection statistics (N, df) naturally exclude hidden docs
-                // -- closing the side-channel that post-filtering (the default) leaves open.
-                query = new ConstantScoreQuery(
-                    new BooleanQuery.Builder().add(query, Occur.MUST).add(aliasFilter, Occur.FILTER).build()
-                );
+                if (useFilteredStatistics()) {
+                    // Pre-filter enforcement, filtered_stats scoring: keep real BM25 scoring but restrict the
+                    // query to the visible subset by adding the alias filter as a normal (non-scoring) FILTER
+                    // clause. The visibility-aware statistics are supplied by ContextIndexSearcher, which computes
+                    // collection/term stats over only the alias-filter bitset (see useFilteredStatistics()). This
+                    // way a term confined to filtered-out docs contributes no df to a visible document's IDF,
+                    // without collapsing scoring to a constant like the constant_score behavior below does.
+                    filters.add(aliasFilter);
+                } else {
+                    // Pre-filter enforcement, constant_score scoring (default): apply the alias filter before
+                    // scoring by wrapping the user's query in a constant-score boolean query. Because scoring runs
+                    // only over the docs that pass the filter, the BM25 collection statistics (N, df) reflect only
+                    // the visible subset, unlike post-filtering (the default) which scores over the whole shard.
+                    query = new ConstantScoreQuery(
+                        new BooleanQuery.Builder().add(query, Occur.MUST).add(aliasFilter, Occur.FILTER).build()
+                    );
+                }
             } else {
                 filters.add(aliasFilter);
             }
@@ -818,6 +855,18 @@ final class DefaultSearchContext extends SearchContext {
     @Override
     public Query aliasFilter() {
         return aliasFilter;
+    }
+
+    @Override
+    public boolean useFilteredStatistics() {
+        // Filtered BM25 statistics apply only when an alias filter is present, the alias is enforced as a
+        // pre_filter, and the filtered_stats scoring sub-behavior has been opted into. Otherwise we keep
+        // whole-shard statistics (post_filter, or pre_filter with the default constant_score behavior).
+        if (aliasFilter == null || filteredStatisticsEnabled() == false) {
+            return false;
+        }
+        AliasFilter requestAliasFilter = request.getAliasFilter();
+        return requestAliasFilter != null && requestAliasFilter.getEnforcement() == AliasFilter.Enforcement.PRE_FILTER;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/opensearch/search/dfs/DfsPhase.java
@@ -39,6 +39,7 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TermStatistics;
 import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.index.query.ParsedQuery;
+import org.opensearch.search.internal.ContextIndexSearcher;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.rescore.RescoreContext;
 
@@ -58,13 +59,24 @@ public class DfsPhase {
         try {
             Map<String, CollectionStatistics> fieldStatistics = new HashMap<>();
             Map<Term, TermStatistics> stats = new HashMap<>();
+            // Filter-aware aliases (A6): when filtered_stats is enabled, the per-shard statistics that this dfs phase
+            // ships to the coordinator must ALSO be restricted to the alias-filter (visible) subset -- otherwise the
+            // coordinator would sum whole-shard numbers and the aggregated statistics would no longer reflect the
+            // visible subset that filtered_stats is meant to score over.
+            // We delegate the actual statistics computation to the ContextIndexSearcher, which applies the filtered
+            // overrides while its aggregatedDfs is still null (the dfs phase runs before AggregatedDfs is assigned).
+            final boolean filteredStatistics = context.useFilteredStatistics() && context.aliasFilter() != null;
+            final ContextIndexSearcher contextSearcher = context.searcher();
             IndexSearcher searcher = new IndexSearcher(context.searcher().getIndexReader()) {
                 @Override
                 public TermStatistics termStatistics(Term term, int docFreq, long totalTermFreq) throws IOException {
                     if (context.isCancelled()) {
                         throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
                     }
-                    TermStatistics ts = super.termStatistics(term, docFreq, totalTermFreq);
+                    // Delegate to the ContextIndexSearcher so filtered (visible-subset) stats are used during dfs.
+                    TermStatistics ts = filteredStatistics
+                        ? contextSearcher.termStatistics(term, docFreq, totalTermFreq)
+                        : super.termStatistics(term, docFreq, totalTermFreq);
                     if (ts != null) {
                         stats.put(term, ts);
                     }
@@ -76,7 +88,10 @@ public class DfsPhase {
                     if (context.isCancelled()) {
                         throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());
                     }
-                    CollectionStatistics cs = super.collectionStatistics(field);
+                    // Delegate to the ContextIndexSearcher so filtered (visible-subset) stats are used during dfs.
+                    CollectionStatistics cs = filteredStatistics
+                        ? contextSearcher.collectionStatistics(field)
+                        : super.collectionStatistics(field);
                     if (cs != null) {
                         fieldStatistics.put(field, cs);
                     }

--- a/server/src/main/java/org/opensearch/search/internal/AliasFilter.java
+++ b/server/src/main/java/org/opensearch/search/internal/AliasFilter.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.search.internal;
 
+import org.opensearch.Version;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -53,19 +55,67 @@ import java.util.Objects;
 @PublicApi(since = "1.0.0")
 public final class AliasFilter implements Writeable, Rewriteable<AliasFilter> {
 
+    /**
+     * Where the alias filter is applied in the query pipeline.
+     * <p>
+     * {@link #POST_FILTER} is the historical behavior: the filter is added as a
+     * post-collection filter, so statistics and scoring still run over every
+     * document in the shard. This is the mode any pre-3.8 node speaks over the
+     * wire, and it is the default for every code path today.
+     * <p>
+     * {@link #PRE_FILTER} is a placeholder for the filter-aware-alias work: the
+     * filter is intended to be pushed into statistics / term-enumeration so the
+     * BM25 side-channel does not leak hidden-doc {@code df}. This enum only
+     * <em>records</em> the choice today &mdash; no code path acts on it yet.
+     * The behavior lands in a follow-up change; see the design notes on
+     * filter-aware aliases.
+     *
+     * @opensearch.experimental
+     */
+    @ExperimentalApi
+    public enum Enforcement implements Writeable {
+        POST_FILTER,
+        PRE_FILTER;
+
+        public static Enforcement readFrom(StreamInput in) throws IOException {
+            return in.readEnum(Enforcement.class);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeEnum(this);
+        }
+    }
+
+    /** First OpenSearch version that carries the {@link Enforcement} field on the wire. */
+    static final Version ENFORCEMENT_VERSION = Version.V_3_8_0;
+
     private final String[] aliases;
     private final QueryBuilder filter;
+    private final Enforcement enforcement;
 
     public static final AliasFilter EMPTY = new AliasFilter(null, Strings.EMPTY_ARRAY);
 
     public AliasFilter(QueryBuilder filter, String... aliases) {
+        this(filter, Enforcement.POST_FILTER, aliases);
+    }
+
+    public AliasFilter(QueryBuilder filter, Enforcement enforcement, String... aliases) {
         this.aliases = aliases == null ? Strings.EMPTY_ARRAY : aliases;
         this.filter = filter;
+        this.enforcement = enforcement == null ? Enforcement.POST_FILTER : enforcement;
     }
 
     public AliasFilter(StreamInput input) throws IOException {
         aliases = input.readStringArray();
         filter = input.readOptionalNamedWriteable(QueryBuilder.class);
+        // BWC: older nodes never write the enforcement field. Default to
+        // POST_FILTER (today's behavior) so mixed-version clusters keep working.
+        if (input.getVersion().onOrAfter(ENFORCEMENT_VERSION)) {
+            enforcement = input.readEnum(Enforcement.class);
+        } else {
+            enforcement = Enforcement.POST_FILTER;
+        }
     }
 
     @Override
@@ -74,7 +124,7 @@ public final class AliasFilter implements Writeable, Rewriteable<AliasFilter> {
         if (queryBuilder != null) {
             QueryBuilder rewrite = Rewriteable.rewrite(queryBuilder, context);
             if (rewrite != queryBuilder) {
-                return new AliasFilter(rewrite, aliases);
+                return new AliasFilter(rewrite, enforcement, aliases);
             }
         }
         return this;
@@ -84,6 +134,10 @@ public final class AliasFilter implements Writeable, Rewriteable<AliasFilter> {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringArray(aliases);
         out.writeOptionalNamedWriteable(filter);
+        if (out.getVersion().onOrAfter(ENFORCEMENT_VERSION)) {
+            out.writeEnum(enforcement);
+        }
+        // Pre-3.8 receivers implicitly treat the field as POST_FILTER.
     }
 
     /**
@@ -101,21 +155,36 @@ public final class AliasFilter implements Writeable, Rewriteable<AliasFilter> {
         return filter;
     }
 
+    /**
+     * Returns where the alias filter should be applied in the query pipeline. Always
+     * non-null; defaults to {@link Enforcement#POST_FILTER} for backward compatibility.
+     * No code path acts on {@link Enforcement#PRE_FILTER} yet &mdash; this is scaffolding
+     * for the filter-aware-alias work.
+     */
+    public Enforcement getEnforcement() {
+        return enforcement;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AliasFilter that = (AliasFilter) o;
-        return Arrays.equals(aliases, that.aliases) && Objects.equals(filter, that.filter);
+        return Arrays.equals(aliases, that.aliases)
+            && Objects.equals(filter, that.filter)
+            && enforcement == that.enforcement;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(Arrays.hashCode(aliases), filter);
+        return Objects.hash(Arrays.hashCode(aliases), filter, enforcement);
     }
 
     @Override
     public String toString() {
-        return "AliasFilter{" + "aliases=" + Arrays.toString(aliases) + ", filter=" + filter + '}';
+        return "AliasFilter{aliases=" + Arrays.toString(aliases)
+            + ", filter=" + filter
+            + ", enforcement=" + enforcement
+            + '}';
     }
 }

--- a/server/src/main/java/org/opensearch/search/internal/AliasFilter.java
+++ b/server/src/main/java/org/opensearch/search/internal/AliasFilter.java
@@ -63,19 +63,46 @@ public final class AliasFilter implements Writeable, Rewriteable<AliasFilter> {
      * document in the shard. This is the mode any pre-3.8 node speaks over the
      * wire, and it is the default for every code path today.
      * <p>
-     * {@link #PRE_FILTER} is a placeholder for the filter-aware-alias work: the
-     * filter is intended to be pushed into statistics / term-enumeration so the
-     * BM25 side-channel does not leak hidden-doc {@code df}. This enum only
-     * <em>records</em> the choice today &mdash; no code path acts on it yet.
-     * The behavior lands in a follow-up change; see the design notes on
+     * {@link #PRE_FILTER} applies the alias filter before scoring / term
+     * enumeration, so BM25 collection statistics reflect only the documents the
+     * alias admits rather than the whole shard. See the design notes on
      * filter-aware aliases.
      *
      * @opensearch.experimental
      */
     @ExperimentalApi
     public enum Enforcement implements Writeable {
-        POST_FILTER,
-        PRE_FILTER;
+        POST_FILTER("post_filter"),
+        PRE_FILTER("pre_filter");
+
+        private final String value;
+
+        Enforcement(String value) {
+            this.value = value;
+        }
+
+        /** The canonical REST/XContent string for this enforcement mode (e.g. {@code "pre_filter"}). */
+        public String value() {
+            return value;
+        }
+
+        /**
+         * Parse an enforcement mode from its REST/XContent string. Returns {@link #POST_FILTER} for a
+         * {@code null} value so an unspecified enforcement keeps today's behavior.
+         *
+         * @throws IllegalArgumentException if {@code value} is non-null but not a known mode
+         */
+        public static Enforcement fromString(String value) {
+            if (value == null) {
+                return POST_FILTER;
+            }
+            for (Enforcement e : values()) {
+                if (e.value.equals(value)) {
+                    return e;
+                }
+            }
+            throw new IllegalArgumentException("unknown alias enforcement [" + value + "], expected one of [post_filter, pre_filter]");
+        }
 
         public static Enforcement readFrom(StreamInput in) throws IOException {
             return in.readEnum(Enforcement.class);
@@ -87,7 +114,14 @@ public final class AliasFilter implements Writeable, Rewriteable<AliasFilter> {
         }
     }
 
-    /** First OpenSearch version that carries the {@link Enforcement} field on the wire. */
+    /**
+     * First OpenSearch version that carries the {@link Enforcement} field on the wire.
+     * <p>
+     * TODO(filter-aware-alias): pinned to V_3_8_0 for now because main is still on 3.8 and V_3_9_0 does
+     * not yet exist; bump to the release this actually ships in once main is bumped. The same gate is
+     * duplicated for this field's other wire representations in IndicesAliasesRequest.AliasActions and
+     * AliasMetadata (grep "TODO(filter-aware-alias)") -- update all three together.
+     */
     static final Version ENFORCEMENT_VERSION = Version.V_3_8_0;
 
     private final String[] aliases;
@@ -158,8 +192,8 @@ public final class AliasFilter implements Writeable, Rewriteable<AliasFilter> {
     /**
      * Returns where the alias filter should be applied in the query pipeline. Always
      * non-null; defaults to {@link Enforcement#POST_FILTER} for backward compatibility.
-     * No code path acts on {@link Enforcement#PRE_FILTER} yet &mdash; this is scaffolding
-     * for the filter-aware-alias work.
+     * {@link Enforcement#PRE_FILTER} causes {@code DefaultSearchContext} to apply the filter
+     * before scoring so BM25 statistics reflect only the documents the alias admits.
      */
     public Enforcement getEnforcement() {
         return enforcement;
@@ -170,9 +204,7 @@ public final class AliasFilter implements Writeable, Rewriteable<AliasFilter> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AliasFilter that = (AliasFilter) o;
-        return Arrays.equals(aliases, that.aliases)
-            && Objects.equals(filter, that.filter)
-            && enforcement == that.enforcement;
+        return Arrays.equals(aliases, that.aliases) && Objects.equals(filter, that.filter) && enforcement == that.enforcement;
     }
 
     @Override
@@ -182,9 +214,6 @@ public final class AliasFilter implements Writeable, Rewriteable<AliasFilter> {
 
     @Override
     public String toString() {
-        return "AliasFilter{aliases=" + Arrays.toString(aliases)
-            + ", filter=" + filter
-            + ", enforcement=" + enforcement
-            + '}';
+        return "AliasFilter{aliases=" + Arrays.toString(aliases) + ", filter=" + filter + ", enforcement=" + enforcement + '}';
     }
 }

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -37,8 +37,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.QueryTimeout;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.CollectionStatistics;
 import org.apache.lucene.search.CollectionTerminatedException;
@@ -65,6 +68,7 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.SparseFixedBitSet;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lease.Releasable;
@@ -121,6 +125,16 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     private QueryProfiler profiler;
     private MutableQueryTimeout cancellable;
     private SearchContext searchContext;
+
+    /**
+     * Per-segment bitsets of the documents that match {@link SearchContext#aliasFilter()}, used to compute
+     * BM25 statistics over only the "visible" subset when {@link SearchContext#useFilteredStatistics()} is true.
+     * Built lazily on first use and cached for the life of the searcher. Indexed by {@link LeafReaderContext#ord}.
+     * A {@code null} entry means "no visible docs in that segment". The whole array being {@code null} means the
+     * bitsets have not been built yet.
+     */
+    private BitSet[] visibleDocsPerSegment;
+    private boolean visibleDocsInitialized = false;
 
     public ContextIndexSearcher(
         IndexReader reader,
@@ -554,6 +568,17 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
 
     @Override
     public TermStatistics termStatistics(Term term, int docFreq, long totalTermFreq) throws IOException {
+        // Filter-aware aliases (filtered_stats): when enabled, compute the statistics over only the documents that
+        // match the alias filter. This branch is checked BEFORE the aggregatedDfs branch on purpose so that it applies
+        // in two of the three cases below (see collectionStatistics for the full reasoning):
+        // 1. Non-dfs query path (aggregatedDfs == null): stats are computed here, filtered.
+        // 2. DFS phase (aggregatedDfs == null): DfsPhase drives statistics collection through this searcher, so the
+        // per-shard stats it ships to the coordinator are already filtered.
+        // The third case -- the query phase of a dfs search (aggregatedDfs != null) -- must NOT recompute: it has to
+        // read the pre-aggregated (already-filtered) stats, so it falls through to the aggregatedDfs branch below.
+        if (useFilteredStatistics() && aggregatedDfs == null) {
+            return filteredTermStatistics(term);
+        }
         if (aggregatedDfs == null) {
             // we are either executing the dfs phase or the search_type doesn't include the dfs phase.
             return super.termStatistics(term, docFreq, totalTermFreq);
@@ -568,6 +593,19 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
 
     @Override
     public CollectionStatistics collectionStatistics(String field) throws IOException {
+        // Filter-aware aliases (filtered_stats). Three cases, and the ordering of the checks matters:
+        // 1. Non-dfs query path: aggregatedDfs == null and useFilteredStatistics() == true. We compute collection
+        // statistics restricted to the visible (alias-filter) subset here, so BM25 N/df reflect only visible docs.
+        // 2. DFS phase of a dfs_query_then_fetch search: aggregatedDfs is also null while DfsPhase collects the
+        // per-shard statistics (it invokes createWeight through this searcher). Because this filtered branch runs
+        // before the aggregatedDfs branch, the per-shard stats DfsPhase ships upward are already filtered, so the
+        // coordinator sums filtered numbers into AggregatedDfs.
+        // 3. Query phase of a dfs search: aggregatedDfs != null. Here we must reuse the coordinator's pre-aggregated
+        // (already filtered, thanks to case 2) statistics rather than recomputing per-shard, so this filtered
+        // branch is intentionally skipped and we fall through to the aggregatedDfs lookup below.
+        if (useFilteredStatistics() && aggregatedDfs == null) {
+            return filteredCollectionStatistics(field);
+        }
         if (aggregatedDfs == null) {
             // we are either executing the dfs phase or the search_type doesn't include the dfs phase.
             return super.collectionStatistics(field);
@@ -578,6 +616,146 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
             return super.collectionStatistics(field);
         }
         return collectionStatistics;
+    }
+
+    private boolean useFilteredStatistics() {
+        return searchContext != null && searchContext.useFilteredStatistics() && searchContext.aliasFilter() != null;
+    }
+
+    /**
+     * Lazily builds and caches the per-segment bitsets of documents matching {@link SearchContext#aliasFilter()}.
+     * These represent the "visible" subset over which filtered BM25 statistics are computed. Only live documents are
+     * included so the counts match what a physically-filtered index would report.
+     */
+    private synchronized BitSet[] getVisibleDocsPerSegment() throws IOException {
+        if (visibleDocsInitialized) {
+            return visibleDocsPerSegment;
+        }
+        final List<LeafReaderContext> leaves = getIndexReader().leaves();
+        final BitSet[] bitSets = new BitSet[leaves.size()];
+        final Query aliasFilter = searchContext.aliasFilter();
+        // COMPLETE_NO_SCORES: we only need the matching doc ids, not scores.
+        final Weight weight = createWeight(rewrite(aliasFilter), ScoreMode.COMPLETE_NO_SCORES, 1f);
+        for (LeafReaderContext ctx : leaves) {
+            final ScorerSupplier scorerSupplier = weight.scorerSupplier(ctx);
+            if (scorerSupplier == null) {
+                continue;
+            }
+            final Scorer scorer = scorerSupplier.get(Long.MAX_VALUE);
+            if (scorer == null) {
+                continue;
+            }
+            final FixedBitSet bitSet = new FixedBitSet(ctx.reader().maxDoc());
+            final DocIdSetIterator iterator = scorer.iterator();
+            final Bits liveDocs = ctx.reader().getLiveDocs();
+            for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
+                if (liveDocs == null || liveDocs.get(doc)) {
+                    bitSet.set(doc);
+                }
+            }
+            if (bitSet.cardinality() > 0) {
+                bitSets[ctx.ord] = bitSet;
+            }
+        }
+        this.visibleDocsPerSegment = bitSets;
+        this.visibleDocsInitialized = true;
+        return bitSets;
+    }
+
+    /**
+     * Computes {@link CollectionStatistics} for a field over only the visible (alias-filter) documents. Mirrors what
+     * Lucene's {@link IndexSearcher#collectionStatistics(String)} does per segment, but intersects the field's postings
+     * with the visible bitset so docCount / sumDocFreq / sumTotalTermFreq reflect the filtered subset. Returns
+     * {@code null} when the field has no visible documents (matching Lucene's "field absent" contract).
+     */
+    private CollectionStatistics filteredCollectionStatistics(String field) throws IOException {
+        final BitSet[] visibleDocs = getVisibleDocsPerSegment();
+        final List<LeafReaderContext> leaves = getIndexReader().leaves();
+        long docCount = 0;       // number of visible docs that have at least one term in this field
+        long sumTotalTermFreq = 0; // total number of (visible) tokens in this field
+        long sumDocFreq = 0;     // sum over terms of the number of visible docs containing the term
+
+        for (LeafReaderContext ctx : leaves) {
+            final BitSet visible = visibleDocs[ctx.ord];
+            if (visible == null) {
+                continue;
+            }
+            final Terms terms = ctx.reader().terms(field);
+            if (terms == null) {
+                continue;
+            }
+            final TermsEnum termsEnum = terms.iterator();
+            final FixedBitSet docsWithField = new FixedBitSet(ctx.reader().maxDoc());
+            PostingsEnum postings = null;
+            while (termsEnum.next() != null) {
+                postings = termsEnum.postings(postings, PostingsEnum.FREQS);
+                int termDocFreq = 0;
+                for (int doc = postings.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = postings.nextDoc()) {
+                    if (visible.get(doc)) {
+                        termDocFreq++;
+                        sumTotalTermFreq += postings.freq();
+                        docsWithField.set(doc);
+                    }
+                }
+                sumDocFreq += termDocFreq;
+            }
+            docCount += docsWithField.cardinality();
+        }
+
+        if (docCount == 0) {
+            // No visible document has this field: report the field as absent, exactly like Lucene does when
+            // docCount would be zero. This avoids violating CollectionStatistics' docCount > 0 invariant.
+            return null;
+        }
+        final long maxDoc = getIndexReader().maxDoc();
+        // Guard Lucene's CollectionStatistics invariants: docCount <= maxDoc, sumDocFreq >= docCount,
+        // sumTotalTermFreq >= sumDocFreq. These naturally hold for exact counts, but clamp defensively.
+        sumDocFreq = Math.max(sumDocFreq, docCount);
+        sumTotalTermFreq = Math.max(sumTotalTermFreq, sumDocFreq);
+        return new CollectionStatistics(field, maxDoc, docCount, sumTotalTermFreq, sumDocFreq);
+    }
+
+    /**
+     * Computes {@link TermStatistics} for a term over only the visible (alias-filter) documents by walking the term's
+     * postings intersected with the visible bitset per segment. Returns {@code null} when no visible document contains
+     * the term (Lucene's "term absent" contract) -- so a term confined to filtered-out docs contributes no BM25 score.
+     */
+    private TermStatistics filteredTermStatistics(Term term) throws IOException {
+        final BitSet[] visibleDocs = getVisibleDocsPerSegment();
+        final List<LeafReaderContext> leaves = getIndexReader().leaves();
+        long docFreq = 0;       // number of visible docs containing the term
+        long totalTermFreq = 0; // sum of term frequencies over visible docs
+
+        for (LeafReaderContext ctx : leaves) {
+            final BitSet visible = visibleDocs[ctx.ord];
+            if (visible == null) {
+                continue;
+            }
+            final Terms terms = ctx.reader().terms(term.field());
+            if (terms == null) {
+                continue;
+            }
+            final TermsEnum termsEnum = terms.iterator();
+            if (termsEnum.seekExact(term.bytes()) == false) {
+                continue;
+            }
+            final PostingsEnum postings = termsEnum.postings(null, PostingsEnum.FREQS);
+            for (int doc = postings.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = postings.nextDoc()) {
+                if (visible.get(doc)) {
+                    docFreq++;
+                    totalTermFreq += postings.freq();
+                }
+            }
+        }
+
+        if (docFreq == 0) {
+            // Term does not occur in any visible document. Returning null matches Lucene's contract for an absent
+            // term and, per TermQuery.TermWeight, results in no scoring contribution over the visible subset.
+            return null;
+        }
+        // TermStatistics requires totalTermFreq >= docFreq (each doc contributes at least one occurrence).
+        totalTermFreq = Math.max(totalTermFreq, docFreq);
+        return new TermStatistics(term.bytes(), docFreq, totalTermFreq);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -365,6 +365,25 @@ public abstract class SearchContext implements Releasable {
 
     public abstract Query aliasFilter();
 
+    /**
+     * Whether BM25 collection/term statistics should be computed over only the documents that match the
+     * {@link #aliasFilter()} (the "visible" subset) instead of the whole shard.
+     * <p>
+     * This backs the {@code filtered_stats} scoring behavior of a {@code pre_filter} alias: relevance ranking
+     * runs as if the shard contained only the visible documents, so a term that appears exclusively in
+     * filtered-out documents does not contribute its document frequency to the BM25 IDF of visible documents.
+     * It is distinct from
+     * the {@code constant_score} pre-filter behavior (which suppresses scoring entirely by wrapping the query in a
+     * {@link org.apache.lucene.search.ConstantScoreQuery}).
+     * <p>
+     * Defaults to {@code false} (whole-shard statistics, today's behavior). When {@code true},
+     * {@link ContextIndexSearcher} computes statistics restricted to the {@link #aliasFilter()} bitset. This is
+     * only meaningful when {@link #aliasFilter()} is non-null.
+     */
+    public boolean useFilteredStatistics() {
+        return false;
+    }
+
     public abstract SearchContext parsedQuery(ParsedQuery query);
 
     public abstract ParsedQuery parsedQuery();

--- a/server/src/test/java/org/opensearch/search/internal/AliasFilterTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/AliasFilterTests.java
@@ -129,8 +129,7 @@ public class AliasFilterTests extends OpenSearchTestCase {
         out.setVersion(legacy);
         original.writeTo(out);
 
-        try (StreamInput raw = out.bytes().streamInput();
-             StreamInput in = new NamedWriteableAwareStreamInput(raw, NAMED_WRITEABLES)) {
+        try (StreamInput raw = out.bytes().streamInput(); StreamInput in = new NamedWriteableAwareStreamInput(raw, NAMED_WRITEABLES)) {
             in.setVersion(legacy);
             final AliasFilter roundTripped = new AliasFilter(in);
             // Old wire format carries no enforcement -> receiver defaults to POST_FILTER.

--- a/server/src/test/java/org/opensearch/search/internal/AliasFilterTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/AliasFilterTests.java
@@ -32,19 +32,30 @@
 
 package org.opensearch.search.internal;
 
+import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.search.SearchModule;
 import org.opensearch.test.EqualsHashCodeTestUtils;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Arrays;
+import java.util.Collections;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class AliasFilterTests extends OpenSearchTestCase {
+
+    private static final NamedWriteableRegistry NAMED_WRITEABLES = new NamedWriteableRegistry(
+        new SearchModule(org.opensearch.common.settings.Settings.EMPTY, Collections.emptyList()).getNamedWriteables()
+    );
 
     public void testEqualsAndHashCode() {
         final QueryBuilder filter = QueryBuilders.termQuery("field", "value");
@@ -72,4 +83,69 @@ public class AliasFilterTests extends OpenSearchTestCase {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(aliasFilter, aliasFilterCopyFunction, aliasFilterMutationFunction);
     }
 
+    /** Enforcement is a new optional field &mdash; the historical two-arg
+     *  constructor (and {@link AliasFilter#EMPTY}) must default it to
+     *  {@link AliasFilter.Enforcement#POST_FILTER} so no existing caller
+     *  changes behavior. */
+    public void testDefaultEnforcementIsPostFilter() {
+        final AliasFilter defaulted = new AliasFilter(QueryBuilders.termQuery("f", "v"), "a0");
+        assertThat(defaulted.getEnforcement(), equalTo(AliasFilter.Enforcement.POST_FILTER));
+        assertThat(AliasFilter.EMPTY.getEnforcement(), equalTo(AliasFilter.Enforcement.POST_FILTER));
+    }
+
+    /** Serialization round-trip at the current (V_3_8_0+) wire version must
+     *  preserve every field, including the new enforcement enum. */
+    public void testSerializationRoundTrip() throws Exception {
+        final AliasFilter original = new AliasFilter(
+            QueryBuilders.termQuery("field", "value"),
+            AliasFilter.Enforcement.PRE_FILTER,
+            "alias_0",
+            "alias_1"
+        );
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            original.writeTo(out);
+            try (StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), NAMED_WRITEABLES)) {
+                final AliasFilter roundTripped = new AliasFilter(in);
+                assertEquals(original, roundTripped);
+                assertThat(roundTripped.getEnforcement(), equalTo(AliasFilter.Enforcement.PRE_FILTER));
+                assertArrayEquals(original.getAliases(), roundTripped.getAliases());
+            }
+        }
+    }
+
+    /** BWC: talking to a pre-3.8 node the enforcement field is not on the wire.
+     *  Receivers must default to POST_FILTER so mixed-version clusters do not
+     *  silently change behavior. */
+    public void testBackwardCompatibilityBeforeEnforcementVersion() throws Exception {
+        final Version legacy = Version.V_3_7_0;
+        assertTrue("test premise: legacy < 3.8 gate", legacy.before(AliasFilter.ENFORCEMENT_VERSION));
+
+        final AliasFilter original = new AliasFilter(
+            QueryBuilders.termQuery("field", "value"),
+            AliasFilter.Enforcement.PRE_FILTER,   // sender records PRE_FILTER
+            "alias_0"
+        );
+        final BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(legacy);
+        original.writeTo(out);
+
+        try (StreamInput raw = out.bytes().streamInput();
+             StreamInput in = new NamedWriteableAwareStreamInput(raw, NAMED_WRITEABLES)) {
+            in.setVersion(legacy);
+            final AliasFilter roundTripped = new AliasFilter(in);
+            // Old wire format carries no enforcement -> receiver defaults to POST_FILTER.
+            assertThat(roundTripped.getEnforcement(), equalTo(AliasFilter.Enforcement.POST_FILTER));
+            assertArrayEquals(original.getAliases(), roundTripped.getAliases());
+        }
+    }
+
+    /** Enforcement participates in equality &mdash; two otherwise-identical
+     *  filters that differ only in enforcement are not equal. */
+    public void testEnforcementParticipatesInEquality() {
+        final QueryBuilder filter = QueryBuilders.termQuery("f", "v");
+        final AliasFilter post = new AliasFilter(filter, AliasFilter.Enforcement.POST_FILTER, "a");
+        final AliasFilter pre = new AliasFilter(filter, AliasFilter.Enforcement.PRE_FILTER, "a");
+        assertNotEquals(post, pre);
+        assertNotEquals(post.hashCode(), pre.hashCode());
+    }
 }


### PR DESCRIPTION
## Summary

Adds **filter-aware aliases** to OpenSearch: a filtered alias can now enforce its
filter **before** query statistics and term enumeration are computed, instead of
only post-filtering the result set. When enabled, this closes a scoring /
term-dictionary side-channel that plain filtered aliases — and, by extension, the
security plugin's DLS post-filtering — leave open, at zero storage and full
freshness.

> Personal feature branch on my fork. Opening this PR against my own `main` for
> review/history, not (yet) upstream.

## Background — the side-channel

A filtered alias narrows the *result set* to matching documents, but the query
still executes against the whole shard:

- **BM25 scoring** uses corpus-wide collection statistics
  (`idf = log(1 + (N - df + 0.5)/(df + 0.5))`, where `N`/`df` span every document,
  including hidden ones). A term appearing only in hidden documents has an
  inflated `df`, which depresses its score. A restricted user who can write a
  document and read back its score can detect hidden terms — the *ExactOracle*.
- **Term enumeration** (`prefix`/`wildcard`/`fuzzy`/`match_phrase_prefix`) expands
  against the full term dictionary — the *PrefixOracle*.

Both exist because the filter is applied *after* statistics and the term
dictionary have been consulted over all documents.

## What this adds

A new `enforcement` setting on an alias `add` action:

| Value | Behavior |
|---|---|
| `post_filter` (default) | Historical behavior — filter applied post-collection; statistics run over the whole shard. Unchanged. |
| `pre_filter` | Filter applied before scoring; statistics reflect only the visible subset, so the side-channel does not leak. |

```
POST /_aliases
{ "actions": [ { "add": {
    "index": "patients", "alias": "cardiology-view",
    "filter": { "term": { "dept": "cardiology" } },
    "enforcement": "pre_filter"
} } ] }
```

`pre_filter` has two scoring sub-behaviors:

1. **`constant_score`** (default for `pre_filter`) — the query is wrapped in
   `ConstantScoreQuery(BooleanQuery(MUST=query, FILTER=aliasFilter))`; no IDF is
   computed, so there is no scoring channel to leak. Fits the common security
   case where ranking is not required.
2. **`filtered_stats`** — real BM25 scoring, but `CollectionStatistics`
   (`N_f`, `docCount_f`) and `TermStatistics` (`df_f`, `ttf_f`) are computed over
   the visible-document bitset, so ranking works over the visible subset and still
   leaks nothing. Opt-in via the
   `opensearch.filter_aware_alias.filtered_stats` system property (read per
   request), keeping `constant_score` the default while this sub-behavior is
   experimental.

## Design / data flow

```
REST enforcement -> IndicesAliasesRequest.AliasActions   (parse + version-gated wire)
  -> AliasAction.Add -> AliasMetadata                    (cluster state, version-gated)
  -> IndicesService.buildAliasFilter                     (metadata -> AliasFilter.Enforcement)
  -> AliasFilter.Enforcement (PRE_FILTER)
  -> DefaultSearchContext                                (constant-score wrap OR plain filter clause)
  -> ContextIndexSearcher                                (filtered CollectionStatistics/TermStatistics)
```

- The `enforcement` field is on the wire only between nodes at `V_3_8_0`+; older
  nodes never see it and behave as `post_filter`, so mixed-version clusters are
  unaffected.
- `AliasFilter.Enforcement` is `@ExperimentalApi`.
- **`dfs_query_then_fetch`:** the DFS phase's per-shard statistics use the same
  filtered overrides, so coordinator-aggregated stats are filtered too. The
  filtered branch is evaluated before the `aggregatedDfs` branch; the three cases
  (non-dfs query, dfs-phase compute, dfs query-phase read) are documented in
  `ContextIndexSearcher`.

## Testing

`FilterAwareAliasIT` proves the behavior on a live cluster:

- `testPreFilterClosesScoringSideChannelWhilePostFilterLeaks` — through a
  `post_filter` alias a hidden-only term scores **below** a control term (the
  leak); through `pre_filter` they score **identically** (closed). Both views
  return the same visible set.
- `testPreFilterClosesPrefixScoringChannel` — same contrast for a
  `match_phrase_prefix` expansion (the PrefixOracle scoring path).
- `testFilteredStatisticsMatchPhysicallyFilteredIndex` — the `filtered_stats`
  BM25 score **equals** the score from a physically-filtered visible-only index
  (ground-truth `df`/`N` correctness, not merely "lower").

Regression: **101 tests** across alias / rollover / dfs / `ContextIndexSearcher`
green; `AliasFilterTests` covers serialization + pre-3.8 wire BWC.

## Scope / follow-ups (not in this PR)

- **Raw term-dictionary APIs (A5b)** — `terms` / `suggest` / `_termvectors` with
  term statistics bypass the per-request query filter and are **not** covered;
  they need the enumeration itself intersected with the alias bitset. Documented
  in `FILTER_AWARE_ALIASES.md`.
- **Per-user templated filters + DLS-role bridge (A7/A8)** — live in the
  `opensearch-project/security` repo; design is sketched in
  `FILTER_AWARE_ALIASES.md`. This PR provides the core mechanism they build on.
- **`filtered_stats` as a first-class wire-level scoring mode** — currently gated
  behind a system property rather than an alias field.

## Backward compatibility

Default is `post_filter` — existing aliases, queries, and mixed-version clusters
behave exactly as before. No default path changes.

See `server/.../action/admin/indices/alias/FILTER_AWARE_ALIASES.md` for the full
design note.
